### PR TITLE
[fix] Missing quotes in descritpion field of BGA-144

### DIFF
--- a/BGA-144_12x12_13.0x13.0mm_Pitch1.0mm.kicad_mod
+++ b/BGA-144_12x12_13.0x13.0mm_Pitch1.0mm.kicad_mod
@@ -1,5 +1,5 @@
 (module BGA-144_12x12_13.0x13.0mm_Pitch1.0mm (layer F.Cu) (tedit 5897535C)
-  (descr BGA-144, http://www.topline.tv/drawings/pdf/BGA%201,0mm%20pitch/LBGA144T1.0-DC128.pdf)
+  (descr "BGA-144, http://www.topline.tv/drawings/pdf/BGA%201,0mm%20pitch/LBGA144T1.0-DC128.pdf")
   (tags BGA-144)
   (attr smd)
   (fp_text reference REF** (at 0 -7.5) (layer F.SilkS)


### PR DESCRIPTION
Fix for issue reported over at reddit (parse error in housings_bga.pretty)
It seems adding a url to the description without using quotes around it breaks the parser.
https://www.reddit.com/r/KiCad/comments/67ugsx/kicad_parse_error_when_trying_to_generate_pcb/
